### PR TITLE
Move the check for krb5_klog_syslog after the krb5_db_fetch_mkey check.

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -235,12 +235,6 @@ if [[ "$build_server" = 1 ]]; then
     ])
   ])
 
-  AC_SEARCH_LIBS(krb5_klog_syslog, kadm5srv, [
-    AC_SUBST([LIBS], ["-lkadm5srv"])
-  ], [AC_MSG_FAILURE([
-    krb5_klog_syslog in libkadm5srv is missing.
-  ])])
-
   AC_MSG_CHECKING(8-argument krb5_db_fetch_mkey() with KVNO)
   AC_TRY_LINK([#include <unistd.h>
 #include <krb5.h>
@@ -253,6 +247,12 @@ if [[ "$build_server" = 1 ]]; then
   ],[
     AC_MSG_RESULT(not 8-argument)
   ])
+
+  AC_SEARCH_LIBS(krb5_klog_syslog, kadm5srv, [
+    AC_SUBST([LIBS], ["-lkadm5srv"])
+  ], [AC_MSG_FAILURE([
+    krb5_klog_syslog in libkadm5srv is missing.
+  ])])
 fi
 
 


### PR DESCRIPTION
Because the former sets LIBS, which AC_TRY_LINK() uses, it changes the
result of AC_TRY_LINK().

Sorry for this, I tested and tested, but once it was actually merged, it started throwing errors which took quite a while to find.